### PR TITLE
Add new constructor parameter to choose a custom EventSource implementation

### DIFF
--- a/src/reconnecting-eventsource.js
+++ b/src/reconnecting-eventsource.js
@@ -22,8 +22,9 @@
 
 export default class ReconnectingEventSource {
 
-    constructor(url, configuration) {
+    constructor(url, configuration, eventSourceClass) {
         this._configuration = configuration != null ? Object.assign({}, configuration) : null;
+        this._eventSourceClass = eventSourceClass != null ? eventSourceClass : EventSource;
 
         this._eventSource = null;
         this._lastEventId = null;
@@ -63,7 +64,7 @@ export default class ReconnectingEventSource {
             url += 'lastEventId=' + encodeURIComponent(this._lastEventId);
         }
 
-        this._eventSource = new EventSource(url, this._configuration);
+        this._eventSource = new this._eventSourceClass(url, this._configuration);
 
         this._eventSource.onopen = event => { this._onopen(event); };
         this._eventSource.onerror = event => { this._onerror(event); };


### PR DESCRIPTION
Hi,
I'm currently using this library with a custom EventSource library called [eventsource](https://github.com/EventSource/eventsource) (and it works great), but I have first to override the EventSource class provided by the browser by doing:
````
import ReconnectingEventSource from 'reconnecting-eventsource';
import { default as CustomEventSource } from 'eventsource';

// NB: "globalThis.EventSource = CustomEventSource;" would also work.
window.EventSource = CustomEventSource;

new ReconnectingEventSource('myUrl', {});
````

It would actually be great to be able to provide the custom EventSource class as a third parameter to the constructor, for example:
````
import ReconnectingEventSource from 'reconnecting-eventsource';
import { default as CustomEventSource } from 'eventsource';

new ReconnectingEventSource('myUrl', {}, CustomEventSource);
````

My patch is doing this, assuming that custom EventSource classes can be instantiated the same way as the original EventSource class. 

Thierry.
